### PR TITLE
Add context

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -130,7 +130,7 @@ func createCallback(scope *Scope) {
 
 		// execute create sql: no primaryField
 		if primaryField == nil {
-			if result, err := scope.SQLDB().Exec(scope.SQL, scope.SQLVars...); scope.Err(err) == nil {
+			if result, err := scope.SQLDB().ExecContext(scope.db.ctx, scope.SQL, scope.SQLVars...); scope.Err(err) == nil {
 				// set rows affected count
 				scope.db.RowsAffected, _ = result.RowsAffected()
 
@@ -146,7 +146,7 @@ func createCallback(scope *Scope) {
 
 		// execute create sql: lastInsertID implemention for majority of dialects
 		if lastInsertIDReturningSuffix == "" && lastInsertIDOutputInterstitial == "" {
-			if result, err := scope.SQLDB().Exec(scope.SQL, scope.SQLVars...); scope.Err(err) == nil {
+			if result, err := scope.SQLDB().ExecContext(scope.db.ctx, scope.SQL, scope.SQLVars...); scope.Err(err) == nil {
 				// set rows affected count
 				scope.db.RowsAffected, _ = result.RowsAffected()
 
@@ -162,7 +162,7 @@ func createCallback(scope *Scope) {
 
 		// execute create sql: dialects with additional lastInsertID requirements (currently postgres & mssql)
 		if primaryField.Field.CanAddr() {
-			if err := scope.SQLDB().QueryRow(scope.SQL, scope.SQLVars...).Scan(primaryField.Field.Addr().Interface()); scope.Err(err) == nil {
+			if err := scope.SQLDB().QueryRowContext(scope.db.ctx, scope.SQL, scope.SQLVars...).Scan(primaryField.Field.Addr().Interface()); scope.Err(err) == nil {
 				primaryField.IsBlank = false
 				scope.db.RowsAffected = 1
 			}

--- a/callback_query.go
+++ b/callback_query.go
@@ -69,7 +69,7 @@ func queryCallback(scope *Scope) {
 			scope.SQL += addExtraSpaceIfExist(fmt.Sprint(str))
 		}
 
-		if rows, err := scope.SQLDB().Query(scope.SQL, scope.SQLVars...); scope.Err(err) == nil {
+		if rows, err := scope.SQLDB().QueryContext(scope.db.ctx, scope.SQL, scope.SQLVars...); scope.Err(err) == nil {
 			defer rows.Close()
 
 			columns, _ := rows.Columns()

--- a/callback_row_query.go
+++ b/callback_row_query.go
@@ -33,9 +33,9 @@ func rowQueryCallback(scope *Scope) {
 		}
 
 		if rowResult, ok := result.(*RowQueryResult); ok {
-			rowResult.Row = scope.SQLDB().QueryRow(scope.SQL, scope.SQLVars...)
+			rowResult.Row = scope.SQLDB().QueryRowContext(scope.db.ctx, scope.SQL, scope.SQLVars...)
 		} else if rowsResult, ok := result.(*RowsQueryResult); ok {
-			rowsResult.Rows, rowsResult.Error = scope.SQLDB().Query(scope.SQL, scope.SQLVars...)
+			rowsResult.Rows, rowsResult.Error = scope.SQLDB().QueryContext(scope.db.ctx, scope.SQL, scope.SQLVars...)
 		}
 	}
 }

--- a/customize_column_test.go
+++ b/customize_column_test.go
@@ -26,7 +26,7 @@ func TestCustomizeColumn(t *testing.T) {
 	DB.AutoMigrate(&CustomizeColumn{})
 
 	scope := DB.NewScope(&CustomizeColumn{})
-	if !scope.Dialect().HasColumn(scope.TableName(), col) {
+	if !scope.Dialect().HasColumn(scope.Context(), scope.TableName(), col) {
 		t.Errorf("CustomizeColumn should have column %s", col)
 	}
 

--- a/dialect.go
+++ b/dialect.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"reflect"
@@ -24,17 +25,17 @@ type Dialect interface {
 	DataTypeOf(field *StructField) string
 
 	// HasIndex check has index or not
-	HasIndex(tableName string, indexName string) bool
+	HasIndex(ctx context.Context, tableName string, indexName string) bool
 	// HasForeignKey check has foreign key or not
-	HasForeignKey(tableName string, foreignKeyName string) bool
+	HasForeignKey(ctx context.Context, tableName string, foreignKeyName string) bool
 	// RemoveIndex remove index
-	RemoveIndex(tableName string, indexName string) error
+	RemoveIndex(ctx context.Context, tableName string, indexName string) error
 	// HasTable check has table or not
-	HasTable(tableName string) bool
+	HasTable(ctx context.Context, tableName string) bool
 	// HasColumn check has column or not
-	HasColumn(tableName string, columnName string) bool
+	HasColumn(ctx context.Context, tableName string, columnName string) bool
 	// ModifyColumn modify column's type
-	ModifyColumn(tableName string, columnName string, typ string) error
+	ModifyColumn(ctx context.Context, tableName string, columnName string, typ string) error
 
 	// LimitAndOffsetSQL return generated SQL with Limit and Offset, as mssql has special case
 	LimitAndOffsetSQL(limit, offset interface{}) (string, error)
@@ -54,7 +55,7 @@ type Dialect interface {
 	NormalizeIndexAndColumn(indexName, columnName string) (string, string)
 
 	// CurrentDatabase return current database name
-	CurrentDatabase() string
+	CurrentDatabase(ctx context.Context) string
 }
 
 var dialectsMap = map[string]Dialect{}
@@ -138,10 +139,10 @@ var ParseFieldStructForDialect = func(field *StructField, dialect Dialect) (fiel
 	return fieldValue, dataType, size, strings.TrimSpace(additionalType)
 }
 
-func currentDatabaseAndTable(dialect Dialect, tableName string) (string, string) {
+func currentDatabaseAndTable(ctx context.Context, dialect Dialect, tableName string) (string, string) {
 	if strings.Contains(tableName, ".") {
 		splitStrings := strings.SplitN(tableName, ".", 2)
 		return splitStrings[0], splitStrings[1]
 	}
-	return dialect.CurrentDatabase(), tableName
+	return dialect.CurrentDatabase(ctx), tableName
 }

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -99,43 +100,43 @@ func (s *commonDialect) DataTypeOf(field *StructField) string {
 	return fmt.Sprintf("%v %v", sqlType, additionalType)
 }
 
-func (s commonDialect) HasIndex(tableName string, indexName string) bool {
+func (s commonDialect) HasIndex(ctx context.Context, tableName string, indexName string) bool {
 	var count int
-	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
-	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema = ? AND table_name = ? AND index_name = ?", currentDatabase, tableName, indexName).Scan(&count)
+	currentDatabase, tableName := currentDatabaseAndTable(ctx, &s, tableName)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM INFORMATION_SCHEMA.STATISTICS WHERE table_schema = ? AND table_name = ? AND index_name = ?", currentDatabase, tableName, indexName).Scan(&count)
 	return count > 0
 }
 
-func (s commonDialect) RemoveIndex(tableName string, indexName string) error {
-	_, err := s.db.Exec(fmt.Sprintf("DROP INDEX %v", indexName))
+func (s commonDialect) RemoveIndex(ctx context.Context, tableName string, indexName string) error {
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf("DROP INDEX %v", indexName))
 	return err
 }
 
-func (s commonDialect) HasForeignKey(tableName string, foreignKeyName string) bool {
+func (s commonDialect) HasForeignKey(ctx context.Context, tableName string, foreignKeyName string) bool {
 	return false
 }
 
-func (s commonDialect) HasTable(tableName string) bool {
+func (s commonDialect) HasTable(ctx context.Context, tableName string) bool {
 	var count int
-	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
-	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ? AND table_name = ?", currentDatabase, tableName).Scan(&count)
+	currentDatabase, tableName := currentDatabaseAndTable(ctx, &s, tableName)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM INFORMATION_SCHEMA.TABLES WHERE table_schema = ? AND table_name = ?", currentDatabase, tableName).Scan(&count)
 	return count > 0
 }
 
-func (s commonDialect) HasColumn(tableName string, columnName string) bool {
+func (s commonDialect) HasColumn(ctx context.Context, tableName string, columnName string) bool {
 	var count int
-	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
-	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ? AND column_name = ?", currentDatabase, tableName, columnName).Scan(&count)
+	currentDatabase, tableName := currentDatabaseAndTable(ctx, &s, tableName)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE table_schema = ? AND table_name = ? AND column_name = ?", currentDatabase, tableName, columnName).Scan(&count)
 	return count > 0
 }
 
-func (s commonDialect) ModifyColumn(tableName string, columnName string, typ string) error {
-	_, err := s.db.Exec(fmt.Sprintf("ALTER TABLE %v ALTER COLUMN %v TYPE %v", tableName, columnName, typ))
+func (s commonDialect) ModifyColumn(ctx context.Context, tableName string, columnName string, typ string) error {
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %v ALTER COLUMN %v TYPE %v", tableName, columnName, typ))
 	return err
 }
 
-func (s commonDialect) CurrentDatabase() (name string) {
-	s.db.QueryRow("SELECT DATABASE()").Scan(&name)
+func (s commonDialect) CurrentDatabase(ctx context.Context) (name string) {
+	s.db.QueryRowContext(ctx, "SELECT DATABASE()").Scan(&name)
 	return
 }
 

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -91,32 +92,32 @@ func (s *postgres) DataTypeOf(field *StructField) string {
 	return fmt.Sprintf("%v %v", sqlType, additionalType)
 }
 
-func (s postgres) HasIndex(tableName string, indexName string) bool {
+func (s postgres) HasIndex(ctx context.Context, tableName string, indexName string) bool {
 	var count int
-	s.db.QueryRow("SELECT count(*) FROM pg_indexes WHERE tablename = $1 AND indexname = $2 AND schemaname = CURRENT_SCHEMA()", tableName, indexName).Scan(&count)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM pg_indexes WHERE tablename = $1 AND indexname = $2 AND schemaname = CURRENT_SCHEMA()", tableName, indexName).Scan(&count)
 	return count > 0
 }
 
-func (s postgres) HasForeignKey(tableName string, foreignKeyName string) bool {
+func (s postgres) HasForeignKey(ctx context.Context, tableName string, foreignKeyName string) bool {
 	var count int
-	s.db.QueryRow("SELECT count(con.conname) FROM pg_constraint con WHERE $1::regclass::oid = con.conrelid AND con.conname = $2 AND con.contype='f'", tableName, foreignKeyName).Scan(&count)
+	s.db.QueryRowContext(ctx, "SELECT count(con.conname) FROM pg_constraint con WHERE $1::regclass::oid = con.conrelid AND con.conname = $2 AND con.contype='f'", tableName, foreignKeyName).Scan(&count)
 	return count > 0
 }
 
-func (s postgres) HasTable(tableName string) bool {
+func (s postgres) HasTable(ctx context.Context, tableName string) bool {
 	var count int
-	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_name = $1 AND table_type = 'BASE TABLE' AND table_schema = CURRENT_SCHEMA()", tableName).Scan(&count)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_name = $1 AND table_type = 'BASE TABLE' AND table_schema = CURRENT_SCHEMA()", tableName).Scan(&count)
 	return count > 0
 }
 
-func (s postgres) HasColumn(tableName string, columnName string) bool {
+func (s postgres) HasColumn(ctx context.Context, tableName string, columnName string) bool {
 	var count int
-	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.columns WHERE table_name = $1 AND column_name = $2 AND table_schema = CURRENT_SCHEMA()", tableName, columnName).Scan(&count)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM INFORMATION_SCHEMA.columns WHERE table_name = $1 AND column_name = $2 AND table_schema = CURRENT_SCHEMA()", tableName, columnName).Scan(&count)
 	return count > 0
 }
 
-func (s postgres) CurrentDatabase() (name string) {
-	s.db.QueryRow("SELECT CURRENT_DATABASE()").Scan(&name)
+func (s postgres) CurrentDatabase(ctx context.Context) (name string) {
+	s.db.QueryRowContext(ctx, "SELECT CURRENT_DATABASE()").Scan(&name)
 	return
 }
 

--- a/dialect_sqlite3.go
+++ b/dialect_sqlite3.go
@@ -1,6 +1,7 @@
 package gorm
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"strings"
@@ -70,25 +71,25 @@ func (s *sqlite3) DataTypeOf(field *StructField) string {
 	return fmt.Sprintf("%v %v", sqlType, additionalType)
 }
 
-func (s sqlite3) HasIndex(tableName string, indexName string) bool {
+func (s sqlite3) HasIndex(ctx context.Context, tableName string, indexName string) bool {
 	var count int
-	s.db.QueryRow(fmt.Sprintf("SELECT count(*) FROM sqlite_master WHERE tbl_name = ? AND sql LIKE '%%INDEX %v ON%%'", indexName), tableName).Scan(&count)
+	s.db.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM sqlite_master WHERE tbl_name = ? AND sql LIKE '%%INDEX %v ON%%'", indexName), tableName).Scan(&count)
 	return count > 0
 }
 
-func (s sqlite3) HasTable(tableName string) bool {
+func (s sqlite3) HasTable(ctx context.Context, tableName string) bool {
 	var count int
-	s.db.QueryRow("SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?", tableName).Scan(&count)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?", tableName).Scan(&count)
 	return count > 0
 }
 
-func (s sqlite3) HasColumn(tableName string, columnName string) bool {
+func (s sqlite3) HasColumn(ctx context.Context, tableName string, columnName string) bool {
 	var count int
-	s.db.QueryRow(fmt.Sprintf("SELECT count(*) FROM sqlite_master WHERE tbl_name = ? AND (sql LIKE '%%\"%v\" %%' OR sql LIKE '%%%v %%');\n", columnName, columnName), tableName).Scan(&count)
+	s.db.QueryRowContext(ctx, fmt.Sprintf("SELECT count(*) FROM sqlite_master WHERE tbl_name = ? AND (sql LIKE '%%\"%v\" %%' OR sql LIKE '%%%v %%');\n", columnName, columnName), tableName).Scan(&count)
 	return count > 0
 }
 
-func (s sqlite3) CurrentDatabase() (name string) {
+func (s sqlite3) CurrentDatabase(ctx context.Context) (name string) {
 	var (
 		ifaces   = make([]interface{}, 3)
 		pointers = make([]*string, 3)
@@ -97,7 +98,7 @@ func (s sqlite3) CurrentDatabase() (name string) {
 	for i = 0; i < 3; i++ {
 		ifaces[i] = &pointers[i]
 	}
-	if err := s.db.QueryRow("PRAGMA database_list").Scan(ifaces...); err != nil {
+	if err := s.db.QueryRowContext(ctx, "PRAGMA database_list").Scan(ifaces...); err != nil {
 		return
 	}
 	if pointers[1] != nil {

--- a/dialects/mssql/mssql.go
+++ b/dialects/mssql/mssql.go
@@ -1,6 +1,7 @@
 package mssql
 
 import (
+	"context"
 	"database/sql/driver"
 	"encoding/json"
 	"errors"
@@ -122,21 +123,21 @@ func (s mssql) fieldCanAutoIncrement(field *gorm.StructField) bool {
 	return field.IsPrimaryKey
 }
 
-func (s mssql) HasIndex(tableName string, indexName string) bool {
+func (s mssql) HasIndex(ctx context.Context, tableName string, indexName string) bool {
 	var count int
-	s.db.QueryRow("SELECT count(*) FROM sys.indexes WHERE name=? AND object_id=OBJECT_ID(?)", indexName, tableName).Scan(&count)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM sys.indexes WHERE name=? AND object_id=OBJECT_ID(?)", indexName, tableName).Scan(&count)
 	return count > 0
 }
 
-func (s mssql) RemoveIndex(tableName string, indexName string) error {
-	_, err := s.db.Exec(fmt.Sprintf("DROP INDEX %v ON %v", indexName, s.Quote(tableName)))
+func (s mssql) RemoveIndex(ctx context.Context, tableName string, indexName string) error {
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf("DROP INDEX %v ON %v", indexName, s.Quote(tableName)))
 	return err
 }
 
-func (s mssql) HasForeignKey(tableName string, foreignKeyName string) bool {
+func (s mssql) HasForeignKey(ctx context.Context, tableName string, foreignKeyName string) bool {
 	var count int
-	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
-	s.db.QueryRow(`SELECT count(*) 
+	currentDatabase, tableName := currentDatabaseAndTable(ctx, &s, tableName)
+	s.db.QueryRowContext(ctx, `SELECT count(*) 
 	FROM sys.foreign_keys as F inner join sys.tables as T on F.parent_object_id=T.object_id 
 		inner join information_schema.tables as I on I.TABLE_NAME = T.name 
 	WHERE F.name = ? 
@@ -144,27 +145,27 @@ func (s mssql) HasForeignKey(tableName string, foreignKeyName string) bool {
 	return count > 0
 }
 
-func (s mssql) HasTable(tableName string) bool {
+func (s mssql) HasTable(ctx context.Context, tableName string) bool {
 	var count int
-	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
-	s.db.QueryRow("SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_name = ? AND table_catalog = ?", tableName, currentDatabase).Scan(&count)
+	currentDatabase, tableName := currentDatabaseAndTable(ctx, &s, tableName)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM INFORMATION_SCHEMA.tables WHERE table_name = ? AND table_catalog = ?", tableName, currentDatabase).Scan(&count)
 	return count > 0
 }
 
-func (s mssql) HasColumn(tableName string, columnName string) bool {
+func (s mssql) HasColumn(ctx context.Context, tableName string, columnName string) bool {
 	var count int
-	currentDatabase, tableName := currentDatabaseAndTable(&s, tableName)
-	s.db.QueryRow("SELECT count(*) FROM information_schema.columns WHERE table_catalog = ? AND table_name = ? AND column_name = ?", currentDatabase, tableName, columnName).Scan(&count)
+	currentDatabase, tableName := currentDatabaseAndTable(ctx, &s, tableName)
+	s.db.QueryRowContext(ctx, "SELECT count(*) FROM information_schema.columns WHERE table_catalog = ? AND table_name = ? AND column_name = ?", currentDatabase, tableName, columnName).Scan(&count)
 	return count > 0
 }
 
-func (s mssql) ModifyColumn(tableName string, columnName string, typ string) error {
-	_, err := s.db.Exec(fmt.Sprintf("ALTER TABLE %v ALTER COLUMN %v %v", tableName, columnName, typ))
+func (s mssql) ModifyColumn(ctx context.Context, tableName string, columnName string, typ string) error {
+	_, err := s.db.ExecContext(ctx, fmt.Sprintf("ALTER TABLE %v ALTER COLUMN %v %v", tableName, columnName, typ))
 	return err
 }
 
-func (s mssql) CurrentDatabase() (name string) {
-	s.db.QueryRow("SELECT DB_NAME() AS [Current Database]").Scan(&name)
+func (s mssql) CurrentDatabase(ctx context.Context) (name string) {
+	s.db.QueryRowContext(ctx, "SELECT DB_NAME() AS [Current Database]").Scan(&name)
 	return
 }
 
@@ -220,12 +221,12 @@ func (mssql) NormalizeIndexAndColumn(indexName, columnName string) (string, stri
 	return indexName, columnName
 }
 
-func currentDatabaseAndTable(dialect gorm.Dialect, tableName string) (string, string) {
+func currentDatabaseAndTable(ctx context.Context, dialect gorm.Dialect, tableName string) (string, string) {
 	if strings.Contains(tableName, ".") {
 		splitStrings := strings.SplitN(tableName, ".", 2)
 		return splitStrings[0], splitStrings[1]
 	}
-	return dialect.CurrentDatabase(), tableName
+	return dialect.CurrentDatabase(ctx), tableName
 }
 
 // JSON type to support easy handling of JSON data in character table fields

--- a/embedded_struct_test.go
+++ b/embedded_struct_test.go
@@ -27,9 +27,11 @@ type EngadgetPost struct {
 }
 
 func TestPrefixColumnNameForEmbeddedStruct(t *testing.T) {
-	dialect := DB.NewScope(&EngadgetPost{}).Dialect()
+	scope := DB.NewScope(&EngadgetPost{})
+	dialect := scope.Dialect()
+	ctx := scope.Context()
 	engadgetPostScope := DB.NewScope(&EngadgetPost{})
-	if !dialect.HasColumn(engadgetPostScope.TableName(), "author_id") || !dialect.HasColumn(engadgetPostScope.TableName(), "author_name") || !dialect.HasColumn(engadgetPostScope.TableName(), "author_email") {
+	if !dialect.HasColumn(ctx, engadgetPostScope.TableName(), "author_id") || !dialect.HasColumn(ctx, engadgetPostScope.TableName(), "author_name") || !dialect.HasColumn(ctx, engadgetPostScope.TableName(), "author_email") {
 		t.Errorf("should has prefix for embedded columns")
 	}
 
@@ -38,7 +40,7 @@ func TestPrefixColumnNameForEmbeddedStruct(t *testing.T) {
 	}
 
 	hnScope := DB.NewScope(&HNPost{})
-	if !dialect.HasColumn(hnScope.TableName(), "user_id") || !dialect.HasColumn(hnScope.TableName(), "user_name") || !dialect.HasColumn(hnScope.TableName(), "user_email") {
+	if !dialect.HasColumn(ctx, hnScope.TableName(), "user_id") || !dialect.HasColumn(ctx, hnScope.TableName(), "user_name") || !dialect.HasColumn(ctx, hnScope.TableName(), "user_email") {
 		t.Errorf("should has prefix for embedded columns")
 	}
 }

--- a/interface.go
+++ b/interface.go
@@ -7,10 +7,10 @@ import (
 
 // SQLCommon is the minimal database connection functionality gorm requires.  Implemented by *sql.DB.
 type SQLCommon interface {
-	Exec(query string, args ...interface{}) (sql.Result, error)
-	Prepare(query string) (*sql.Stmt, error)
-	Query(query string, args ...interface{}) (*sql.Rows, error)
-	QueryRow(query string, args ...interface{}) *sql.Row
+	ExecContext(ctx context.Context, query string, args ...interface{}) (sql.Result, error)
+	PrepareContext(ctx context.Context, query string) (*sql.Stmt, error)
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*sql.Rows, error)
+	QueryRowContext(ctx context.Context, query string, args ...interface{}) *sql.Row
 }
 
 type sqlDb interface {

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ type DB struct {
 
 	// single db
 	db                SQLCommon
+	ctx               context.Context
 	blockGlobalUpdate bool
 	logMode           logModeValue
 	logger            logger
@@ -84,6 +85,7 @@ func Open(dialect string, args ...interface{}) (db *DB, err error) {
 
 	db = &DB{
 		db:        dbSQL,
+		ctx:       context.TODO(),
 		logger:    defaultLogger,
 		callbacks: DefaultCallback,
 		dialect:   newDialect(dialect, dbSQL),
@@ -228,6 +230,12 @@ func (s *DB) SubQuery() *SqlExpr {
 	scope.prepareQuerySQL()
 
 	return Expr(fmt.Sprintf("(%v)", scope.SQL), scope.SQLVars...)
+}
+
+func (s *DB) WithContext(ctx context.Context) *DB {
+	dbClone := s.clone()
+	dbClone.ctx = ctx
+	return dbClone
 }
 
 // Where return a new relation, filter records with given conditions, accepts `map`, `struct` or `string` as conditions, refer http://jinzhu.github.io/gorm/crud.html#query
@@ -672,7 +680,7 @@ func (s *DB) HasTable(value interface{}) bool {
 		tableName = scope.TableName()
 	}
 
-	has := scope.Dialect().HasTable(tableName)
+	has := scope.Dialect().HasTable(s.ctx, tableName)
 	s.AddError(scope.db.Error)
 	return has
 }
@@ -792,7 +800,7 @@ func (s *DB) SetJoinTableHandler(source interface{}, column string, handler Join
 				destination := (&Scope{Value: reflect.New(field.Struct.Type).Interface()}).GetModelStruct().ModelType
 				handler.Setup(field.Relationship, many2many, source, destination)
 				field.Relationship.JoinTableHandler = handler
-				if table := handler.Table(s); scope.Dialect().HasTable(table) {
+				if table := handler.Table(s); scope.Dialect().HasTable(s.ctx, table) {
 					s.Table(table).AutoMigrate(handler)
 				}
 			}
@@ -839,6 +847,7 @@ func (s *DB) GetErrors() []error {
 func (s *DB) clone() *DB {
 	db := &DB{
 		db:                s.db,
+		ctx:               s.ctx,
 		parent:            s.parent,
 		logger:            s.logger,
 		logMode:           s.logMode,

--- a/migration_test.go
+++ b/migration_test.go
@@ -1,6 +1,7 @@
 package gorm_test
 
 import (
+	"context"
 	"database/sql"
 	"database/sql/driver"
 	"errors"
@@ -307,7 +308,8 @@ func TestIndexes(t *testing.T) {
 	}
 
 	scope := DB.NewScope(&Email{})
-	if !scope.Dialect().HasIndex(scope.TableName(), "idx_email_email") {
+	ctx := scope.Context()
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "idx_email_email") {
 		t.Errorf("Email should have index idx_email_email")
 	}
 
@@ -315,7 +317,7 @@ func TestIndexes(t *testing.T) {
 		t.Errorf("Got error when tried to remove index: %+v", err)
 	}
 
-	if scope.Dialect().HasIndex(scope.TableName(), "idx_email_email") {
+	if scope.Dialect().HasIndex(ctx, scope.TableName(), "idx_email_email") {
 		t.Errorf("Email's index idx_email_email should be deleted")
 	}
 
@@ -323,7 +325,7 @@ func TestIndexes(t *testing.T) {
 		t.Errorf("Got error when tried to create index: %+v", err)
 	}
 
-	if !scope.Dialect().HasIndex(scope.TableName(), "idx_email_email_and_user_id") {
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "idx_email_email_and_user_id") {
 		t.Errorf("Email should have index idx_email_email_and_user_id")
 	}
 
@@ -331,7 +333,7 @@ func TestIndexes(t *testing.T) {
 		t.Errorf("Got error when tried to remove index: %+v", err)
 	}
 
-	if scope.Dialect().HasIndex(scope.TableName(), "idx_email_email_and_user_id") {
+	if scope.Dialect().HasIndex(ctx, scope.TableName(), "idx_email_email_and_user_id") {
 		t.Errorf("Email's index idx_email_email_and_user_id should be deleted")
 	}
 
@@ -339,7 +341,7 @@ func TestIndexes(t *testing.T) {
 		t.Errorf("Got error when tried to create index: %+v", err)
 	}
 
-	if !scope.Dialect().HasIndex(scope.TableName(), "idx_email_email_and_user_id") {
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "idx_email_email_and_user_id") {
 		t.Errorf("Email should have index idx_email_email_and_user_id")
 	}
 
@@ -361,7 +363,7 @@ func TestIndexes(t *testing.T) {
 		t.Errorf("Got error when tried to remove index: %+v", err)
 	}
 
-	if scope.Dialect().HasIndex(scope.TableName(), "idx_email_email_and_user_id") {
+	if scope.Dialect().HasIndex(ctx, scope.TableName(), "idx_email_email_and_user_id") {
 		t.Errorf("Email's index idx_email_email_and_user_id should be deleted")
 	}
 
@@ -391,11 +393,12 @@ func TestAutoMigration(t *testing.T) {
 	DB.Save(&EmailWithIdx{Email: "jinzhu@example.org", UserAgent: "pc", RegisteredAt: &now})
 
 	scope := DB.NewScope(&EmailWithIdx{})
-	if !scope.Dialect().HasIndex(scope.TableName(), "idx_email_agent") {
+	ctx := scope.Context()
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "idx_email_agent") {
 		t.Errorf("Failed to create index")
 	}
 
-	if !scope.Dialect().HasIndex(scope.TableName(), "uix_email_with_idxes_registered_at") {
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "uix_email_with_idxes_registered_at") {
 		t.Errorf("Failed to create index")
 	}
 
@@ -474,23 +477,24 @@ func TestMultipleIndexes(t *testing.T) {
 	DB.Save(&MultipleIndexes{UserID: 1, Name: "jinzhu", Email: "jinzhu@example.org", Other: "foo"})
 
 	scope := DB.NewScope(&MultipleIndexes{})
-	if !scope.Dialect().HasIndex(scope.TableName(), "uix_multipleindexes_user_name") {
+	ctx := scope.Context()
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "uix_multipleindexes_user_name") {
 		t.Errorf("Failed to create index")
 	}
 
-	if !scope.Dialect().HasIndex(scope.TableName(), "uix_multipleindexes_user_email") {
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "uix_multipleindexes_user_email") {
 		t.Errorf("Failed to create index")
 	}
 
-	if !scope.Dialect().HasIndex(scope.TableName(), "uix_multiple_indexes_email") {
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "uix_multiple_indexes_email") {
 		t.Errorf("Failed to create index")
 	}
 
-	if !scope.Dialect().HasIndex(scope.TableName(), "idx_multipleindexes_user_other") {
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "idx_multipleindexes_user_other") {
 		t.Errorf("Failed to create index")
 	}
 
-	if !scope.Dialect().HasIndex(scope.TableName(), "idx_multiple_indexes_other") {
+	if !scope.Dialect().HasIndex(ctx, scope.TableName(), "idx_multiple_indexes_other") {
 		t.Errorf("Failed to create index")
 	}
 
@@ -571,7 +575,7 @@ func TestIndexWithPrefixLength(t *testing.T) {
 			if err := DB.CreateTable(table).Error; err != nil {
 				t.Errorf("Failed to create %s table: %v", tableName, err)
 			}
-			if !scope.Dialect().HasIndex(tableName, "idx_index_with_prefixes_length") {
+			if !scope.Dialect().HasIndex(context.TODO(), tableName, "idx_index_with_prefixes_length") {
 				t.Errorf("Failed to create %s table index:", tableName)
 			}
 		})


### PR DESCRIPTION
Add execution context to Gorm.

This allows:
- tracking requests IDs (if we need to do tracing at some point)
- canceling queries -> this is important


At the moment, when a GraphQL query times out or is canceled, we let the SQL query run. This change allows passing a context and actually canceling the SQL queries when the context is canceled.


